### PR TITLE
refactor: constant MYSTRING_STRING_ALREADY_FREE is typed wrong (closes #10)

### DIFF
--- a/include/smystring.h
+++ b/include/smystring.h
@@ -29,7 +29,7 @@ enum ErrorMyString {
     /** 
     * @brief Trying to clear an already MyString object. 
     */
-    MYSTRING_STRING_ALREADY_FREE,
+    MYSTRING_PHRASE_ALREADY_RELEASED,
 
     /** 
     * @brief Reallocation memory fails. 
@@ -75,7 +75,7 @@ enum ErrorMyString init_string(struct MyString *object_string);
 *
 * @param object_string Pointer to the MyString object who will free.
 * 
-* @return MYSTRING_NONE on success, MYSTRING_STRING_ALREADY_FREE if your trying to clear an already MyString object.
+* @return MYSTRING_NONE on success, MYSTRING_PHRASE_ALREADY_RELEASED if your trying to clear an already MyString object.
 */
 enum ErrorMyString del_string(struct MyString *object_string);
 

--- a/src/smystring.c
+++ b/src/smystring.c
@@ -34,7 +34,7 @@ enum ErrorMyString del_string(struct MyString *object_string) {
 
     }
 
-    object_string->id_error = MYSTRING_STRING_ALREADY_FREE;
-    return MYSTRING_STRING_ALREADY_FREE;
+    object_string->id_error = MYSTRING_PHRASE_ALREADY_RELEASED;
+    return MYSTRING_PHRASE_ALREADY_RELEASED;
 
 }

--- a/test/smystring/testFreeAString.c
+++ b/test/smystring/testFreeAString.c
@@ -81,7 +81,7 @@ void testFreeAStringAgainMakesAnError() {
 
     del_string(&string);
 
-    cr_assert_eq(string.id_error, MYSTRING_STRING_ALREADY_FREE);
+    cr_assert_eq(string.id_error, MYSTRING_PHRASE_ALREADY_RELEASED);
 
     return;
 


### PR DESCRIPTION
I changed the constant `MYSTRING_STRING_ALREADY_FREE` to `MYSTRING_PHRASE_ALREADY_RELEASED`.

I changed the documentation.

I ran the `test/smystring/testFreeAString.c`.