### PR TITLE
feat: add a function to convert to uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - Assign and compare string values (`assign_string`, `equals_string`);
 - Character count (`counter_string`);
 - Concatenate two `MyString` objects (`concat_string`);
+- To Uppercase (`touppercase_string`);
 - Handle errors internally using `id_error`;
 - Removing all spaces in the string (`remasp_string`);
 - Removing all left spaces and some special character ('\\t', '\\r', '\\n') in the string (`lstrip_string`);

--- a/example/example10_touppercase.c
+++ b/example/example10_touppercase.c
@@ -1,0 +1,63 @@
+/**
+ * Example 10 - Using touppercase_string function.
+ * Demonstrates how to use the touppercase_string function.
+ *
+ * To compile:
+ * gcc example/example10_touppercase.c -Iinclude -Lbuild -lmystring -o example/example10
+ */
+
+
+#include <stdio.h>
+#include "mystring.h"
+
+
+int main () {
+
+    /** 
+     * The Struct of String, if you want you can use the typedef to remove keyword "struct"
+     * 
+     * Initializing two MyString objects
+     */
+    struct MyString example;
+
+
+    // Initializing a String with a phrase "this phrase will be in uppercase"
+    initwp_string(&example, "this phrase will be in uppercase"); 
+
+    if(gete_string(example)) {
+
+        enum ErrorMyString e = gete_string(example);
+
+        printf("Initialization failed with id error [%d]\n", e);
+
+    }
+
+    // To uppercase string 
+    touppercase_string(&example);
+
+    if(gete_string(example)) {
+
+        enum ErrorMyString e = gete_string(example);
+
+        printf("Error in uppercase with id [%d]\n", e);
+
+    }
+
+    printf("%s\n", getp_string(example));
+
+    // Free the String
+    del_string(&example);
+
+    if(gete_string(example)) {
+
+        enum ErrorMyString e = gete_string(example);
+
+        printf("Deletation failed with id error [%d]\n", e);
+
+    }
+
+
+    printf("\n==> Everything worked perfectly. Goodbye! <==\n");
+
+    return 0;
+}

--- a/include/bop_mystring.h
+++ b/include/bop_mystring.h
@@ -105,4 +105,13 @@ enum ErrorMyString remasp_string(struct MyString *object_string);
 enum ErrorMyString lstrip_string(struct MyString *object_string); 
 
 
-#endif 
+/**
+* @brief To uppercase the phrase of MyString object.
+*
+* @param object_string Pointer to the MyString object.
+* 
+* @return MYSTRING_NONE on success, MYSTRING_PHRASE_NOT_INITIALIZED if memory allocation fails, MYSTRING_OPERATION_NEEDS_A_PHRASE if phrase is empty.
+*/
+enum ErrorMyString touppercase_string(struct MyString *object_string);
+
+#endif

--- a/include/smystring.h
+++ b/include/smystring.h
@@ -43,7 +43,12 @@ enum ErrorMyString {
     /** 
     * @brief Relocation memory fails. 
     */
-    MYSTRING_PHRASE_CANNOT_BE_RELOCATED
+    MYSTRING_PHRASE_CANNOT_BE_RELOCATED,
+
+    /** 
+    * @brief Operation needs a phrase and does not have it. 
+    */
+    MYSTRING_OPERATION_NEEDS_A_PHRASE
 };
 
 

--- a/src/bop_mystring.c
+++ b/src/bop_mystring.c
@@ -1,7 +1,7 @@
 #include "smystring.h"
 #include "bop_mystring.h"
 #include <stdlib.h>
-
+#include <ctype.h>
 
 int counter_string(char *buff) {
 
@@ -261,4 +261,61 @@ enum ErrorMyString lstrip_string(struct MyString *object_string) {
 
     del_string(&copy_original_phrase);
     return MYSTRING_NONE;
+}
+
+enum ErrorMyString touppercase_string(struct MyString *object_string) {
+
+    if(object_string->phrase == NULL) {
+        object_string->id_error = MYSTRING_PHRASE_NOT_INITIALIZED;
+        return MYSTRING_PHRASE_NOT_INITIALIZED;    
+    }
+
+    if(object_string->phrase[0] == '\0') {
+        object_string->id_error = MYSTRING_OPERATION_NEEDS_A_PHRASE;
+        return MYSTRING_OPERATION_NEEDS_A_PHRASE;
+    }
+
+
+    // RESET
+    object_string->id_error = ID_ERROR_RESETED;
+
+    int copy_length = object_string->length;
+    object_string->length = LENGTH_RESETED;
+
+    char copy_phrase[copy_length+1];
+
+    for(int i = 0; i < copy_length; i++) {
+        copy_phrase[i] = object_string->phrase[i];
+    }
+
+    copy_phrase[copy_length] = '\0';
+
+
+    // TOUPPER
+    struct MyString temporary_object;
+    char buff[copy_length+1];
+    
+    for(int i = 0; i < copy_length; i++) {
+    
+        char result = toupper(copy_phrase[i]); 
+        buff[i] = result;
+    
+    }
+
+    buff[copy_length] = '\0';
+
+
+    // CLOSING STRING
+    enum ErrorMyString e;
+
+    e = assign_string(object_string, buff);
+    
+    if(e != MYSTRING_NONE) {
+        object_string->id_error = e;
+        object_string->length = copy_length;
+        return e;
+    }
+
+    return MYSTRING_NONE;
+
 }

--- a/test/bop/TestToUppercase.c
+++ b/test/bop/TestToUppercase.c
@@ -1,0 +1,77 @@
+#include "criterion/criterion.h"
+#include "mystring.h"
+
+/**
+ * SCENARIO: 
+ * 
+ * 1. When sending a string with only one character, it should replace the same character, but in uppercase.
+ * 2. When sending a string, it should replace the same character in uppercase.
+ * 3. When sending an object that has not been initialized, it should return the error MYSTRING_PHRASE_NOT_INITIALIZED.
+ * 4. When sending an object and the phrase is empty, it should return the error MYSTRING_OPERATION_NEEDS_A_PHRASE.
+ */
+
+
+Test(TestToUppercase, WhenSendACharacterLowercase_ThenReturnUppercase) {
+
+    struct MyString object;
+    struct MyString expected;
+
+    initwp_string(&object, "a");
+    initwp_string(&expected, "A");
+
+    enum ErrorMyString e = touppercase_string(&object);
+    
+    cr_assert(equals_string(object, expected), "Expected 'A', got %s", object.phrase);
+    cr_assert_eq(object.id_error, MYSTRING_NONE, "Expected MYSTRING_NONE (0), got %d", object.id_error);
+    cr_assert_eq(e, MYSTRING_NONE, "Expected MYSTRING_NONE (0), got %d", e);
+
+    del_string(&object);
+    del_string(&expected);
+
+}
+
+Test(TestToUppercase, WhenSendAPhraseLowercase_ThenReturnToUppercase) {
+
+    struct MyString object;
+    struct MyString expected;
+
+    initwp_string(&object, "foo and bar");
+    initwp_string(&expected, "FOO AND BAR");
+
+    enum ErrorMyString e = touppercase_string(&object);
+
+    cr_assert(equals_string(object, expected), "Expected 'FOO AND BAR', got %s", object.phrase);
+    cr_assert_eq(object.id_error, MYSTRING_NONE, "Expected MYSTRING_NONE (0), got %d", object.id_error);
+    cr_assert_eq(e, MYSTRING_NONE, "Expected MYSTRING_NONE (0), got %d", e);
+
+    del_string(&object);
+    del_string(&expected);
+
+}
+
+Test(TestToUppercase, WhenSendADeletedObject_ThenReturnErrorMyStringPhraseNotInitialized) {
+
+    struct MyString object;
+
+    enum ErrorMyString e = touppercase_string(&object);
+
+    cr_assert_eq(object.id_error, MYSTRING_PHRASE_NOT_INITIALIZED, "Expected MYSTRING_PHRASE_NOT_INITIALIZED (1), got %d", object.id_error);
+    cr_assert_eq(e, MYSTRING_PHRASE_NOT_INITIALIZED, "Expected MYSTRING_PHRASE_NOT_INITIALIZED (1), got %d", e);
+
+    del_string(&object);
+
+}
+
+Test(TestToUppercase, WhenSendAnEmptyPhrase_ThenReturnErrorMyStringOperationNeedsAPhrase) {
+
+    struct MyString object;
+    initwp_string(&object, "");
+
+    enum ErrorMyString e = touppercase_string(&object);
+
+    cr_assert_eq(object.id_error, MYSTRING_OPERATION_NEEDS_A_PHRASE, "Expected MYSTRING_OPERATION_NEEDS_A_PHRASE (4), got %d", object.id_error);
+    cr_assert_eq(e, MYSTRING_OPERATION_NEEDS_A_PHRASE, "Expected MYSTRING_OPERATION_NEEDS_A_PHRASE (4), got %d", e);
+
+    del_string(&object);
+
+}


### PR DESCRIPTION
## Sumary
Implemented a function to `uppercase_string` any string from object MyString.

## Details

### Created
- Constant error called `MYSTRING_OPERATION_NEEDS_A_PHRASE` when phrase cannot be empty in a function.
- Example 10 for teach how to use the `touppercase_string` function.
- Test using Test-Driven Development.
- A signature in header bop file.
- The function in source bop file.
- Documented the function in header bop file.

### Updated
- Add `touppercase_string` in `README.md`.

## Linked issue

Closes #1 