### PR TITLE
feat: add function to check if a string object is equal to a char*

### DIFF
--- a/include/bop_mystring.h
+++ b/include/bop_mystring.h
@@ -114,4 +114,16 @@ enum ErrorMyString lstrip_string(struct MyString *object_string);
 */
 enum ErrorMyString touppercase_string(struct MyString *object_string);
 
+
+/**
+ * @brief Checks if the MyString object's phrase is equal to the given phrase.
+ * 
+ * @param object_string Pointer to the MyString object.
+ * @param phrase The phrase to compare with the MyString object's phrase.
+ * 
+ * @return 1 if the phrases are equal, 0 otherwise.
+ */
+int isequal_string(struct MyString object_string, char *phrase);
+
+
 #endif

--- a/src/bop_mystring.c
+++ b/src/bop_mystring.c
@@ -319,3 +319,18 @@ enum ErrorMyString touppercase_string(struct MyString *object_string) {
     return MYSTRING_NONE;
 
 }
+
+int isequal_string(struct MyString object_string, char *phrase) {
+
+    int length_os = object_string.length;
+    int length_phrase = counter_string(phrase);
+
+    if(length_os != length_phrase) return 0;
+
+    for(int i = 0; i < length_os; i++) {
+        if(object_string.phrase[i] != phrase[i]) return 0; 
+    }
+
+    return 1;
+
+}

--- a/test/bop/TestIsEqualString.c
+++ b/test/bop/TestIsEqualString.c
@@ -1,0 +1,64 @@
+#include <criterion/criterion.h>
+#include <mystring.h>
+
+/**
+ * SCENARIO:
+ * 
+ * 1. Test that two identical strings are considered equal.
+ * 2. Test that two different strings are considered not equal.
+ * 3. Test that two empty strings are considered equal.
+ * 4. Test that strings with different cases are considered not equal.
+ */
+
+
+Test(IsEqualString, WhenTwoIdenticalStrings_ThenReturnTrue) {
+
+    struct MyString object;
+    initwp_string(&object, "foo");
+
+    isequal_string(object, "foo");
+
+    cr_assert_eq(isequal_string(object, "foo"), 1, "Expected 1 (true), got %d", isequal_string(object, "foo"));
+
+    del_string(&object);
+
+}
+
+Test(IsEqualString, WhenTwoDifferentStrings_TheReturnFalse) {
+
+    struct MyString object;
+    initwp_string(&object, "foo");
+
+    isequal_string(object, "bar");
+
+    cr_assert_eq(isequal_string(object, "bar"), 0, "Expected 0 (false), got %d", isequal_string(object, "bar"));
+
+    del_string(&object);
+
+}
+
+Test(IsEqualString, WhenTwoEmptyStrings_ThenReturnTrue) {
+
+    struct MyString object;
+    initwp_string(&object, "");
+
+    isequal_string(object, "");
+
+    cr_assert_eq(isequal_string(object, ""), 1, "Expected 1 (true), got %d", isequal_string(object, ""));
+
+    del_string(&object);
+
+}
+
+Test(IsEqualString, WhenStringsWithDifferentCases_ThenReturnFalse) {
+
+    struct MyString object;
+    initwp_string(&object, "Foo");
+
+    isequal_string(object, "foo");
+
+    cr_assert_eq(isequal_string(object, "foo"), 0, "Expected 0 (false), got %d", isequal_string(object, "foo"));
+
+    del_string(&object);
+
+}


### PR DESCRIPTION
## Sumary
Implemented the function `isequal_string` two compare a Object String and a char*.

## Details

### Created
- Test using Test-Driven Development.
- A signature in header bop file.
- The function in source bop file.
- Documented the function in header bop file.

## Linked issue

Closes #35